### PR TITLE
Add file env.go for checking against env. vars.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,4 +71,5 @@ func readConf(conf *Config) {
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatal(err)
 	}
+	ConsolidateEnvVars(&Global)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,7 @@ func init() {
 		reloadConf()
 		readConf(&Global)
 	}
+	ConsolidateEnvVars(&Global)
 	readSources()
 }
 
@@ -71,5 +72,4 @@ func readConf(conf *Config) {
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatal(err)
 	}
-	ConsolidateEnvVars(&Global)
 }

--- a/config/env.go
+++ b/config/env.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+    "fmt"
+    "os"
+    "reflect"
+    "strings"
+)
+
+//Looks for discrepancies between environment variables and the internal config
+//struct, preferring the value set in the environment variable.
+func ConsolidateEnvVars(conf *Config) {
+    numSubStructs := reflect.ValueOf(conf).Elem().NumField()
+    for i := 0; i < numSubStructs; i++ {
+        var iter reflect.Value
+        var evPrefix string
+        if i == 0 {
+            iter = reflect.ValueOf(&conf.Sources).Elem()
+            evPrefix = "ARKEN_SOURCES_"
+        } else if i == 1 {
+            iter = reflect.ValueOf(&conf.Database).Elem()
+            evPrefix = "ARKEN_DB_"
+        } else {
+            iter = reflect.ValueOf(&conf.General).Elem()
+            evPrefix = "ARKEN_GENERAL_"
+        }
+        var evName string
+        var fieldName string
+        typeOfT := iter.Type()
+        for j := 0; j < iter.NumField(); j++ {
+            f := iter.Field(j)
+            fieldName = typeOfT.Field(j).Name
+            evName = strings.ToUpper(fieldName)
+            evName = evPrefix + evName
+            evVal, evExists := os.LookupEnv(evName)
+            if evExists && evVal != f.String() {
+                iter.FieldByName(fieldName).SetString(evVal)
+                fmt.Printf("Env. var. \"%v\" does not match internal" +
+                    " memory. Updating memory value to \"%v\".\n", evName, evVal)
+            } else if !evExists {
+                fmt.Printf("Env. var \"%v\" not found, using \"%v\".\n", evName, iter.FieldByName(fieldName).String())
+            }
+        }
+    }
+}

--- a/config/env.go
+++ b/config/env.go
@@ -7,8 +7,12 @@ import (
     "strings"
 )
 
+
 //Looks for discrepancies between environment variables and the internal config
 //struct, preferring the value set in the environment variable.
+//In this function, variables starting with "field" track values associated
+//with the struct, and a "ev" prefix indicates the value is associated with the
+//environment variable.
 func ConsolidateEnvVars(conf *Config) {
     numSubStructs := reflect.ValueOf(conf).Elem().NumField()
     for i := 0; i < numSubStructs; i++ {
@@ -24,21 +28,20 @@ func ConsolidateEnvVars(conf *Config) {
             iter = reflect.ValueOf(&conf.General).Elem()
             evPrefix = "ARKEN_GENERAL_"
         }
-        var evName string
-        var fieldName string
-        typeOfT := iter.Type()
+        structType := iter.Type()
         for j := 0; j < iter.NumField(); j++ {
-            f := iter.Field(j)
-            fieldName = typeOfT.Field(j).Name
-            evName = strings.ToUpper(fieldName)
-            evName = evPrefix + evName
-            evVal, evExists := os.LookupEnv(evName)
-            if evExists && evVal != f.String() {
-                iter.FieldByName(fieldName).SetString(evVal)
-                fmt.Printf("Env. var. \"%v\" does not match internal" +
-                    " memory. Updating memory value to \"%v\".\n", evName, evVal)
-            } else if !evExists {
-                fmt.Printf("Env. var \"%v\" not found, using \"%v\".\n", evName, iter.FieldByName(fieldName).String())
+            fieldVal := iter.Field(j).String()
+            if fieldVal != "Version" {
+                fieldName := structType.Field(j).Name
+                evName := evPrefix + strings.ToUpper(fieldName)
+                evVal, evExists := os.LookupEnv(evName)
+                if evExists && evVal != fieldVal {
+                    iter.FieldByName(fieldName).SetString(evVal)
+                    fmt.Printf("Env. var. \"%v\" does not match internal"+
+                        " memory. Updating memory value to \"%v\".\n", evName, evVal)
+                } else if !evExists {
+                    fmt.Printf("Env. var \"%v\" not found, using \"%v\".\n", evName, iter.FieldByName(fieldName).String())
+                }
             }
         }
     }


### PR DESCRIPTION
This file contains only one function. If it finds a discrepancy between
the internal config state and the value of the environment variables, it
will choose the value of the environment variable. This function also
decides how Arken's environment variables are named:
ARKEN_<CATEGORY>_<DESCRIPTOR>
where category is the name of the substruct of struct config.go::config in
which the field was found, and the descriptor is the name of the field.
This commit also changes config.go by adding a call to the new function.
 Changes to be committed:
	modified:   config/config.go
	new file:   config/env.go