### PR TITLE
touch up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,28 @@ A Tool to Create a Distributed Filesystem to Securely Backup the World's Importa
 
 - [A Bit of Backstory](#a-bit-of-backstory)
 - [What is Arken?](#what-is-arken)
-  - [What's a Keyset](#what's-a-keyset)
+  - [What's a Keyset](#whats-a-keyset)
     - [Keyset Security](#keyset-security)
-    - [Rebalancing Data Across the Comunity](#rebalancing-data-across-the-comunity)
+    - [Rebalancing Data Across the Community](#rebalancing-data-across-the-community)
 - [Getting Started](#getting-started)
 - [What's the process as someone who want's to backup important data?](#what's-the-process-as-someone-who-want's-to-backup-important-data?)
 - [What's the process as someone donating their extra storage space?](#what's-the-process-as-someone-donating-their-extra-storage-space?)
 
 ## A Bit of Backstory
 
-Many Researchers, Museums, and Archivists are struggling to host and protect a vast amount of important public data. On the other hand, there are many of us developers, tinkerers, and general computer enthusists who have extra storage space on our home servers.
+Many researchers, museums, and archivists are struggling to host and protect a vast amount of important public data. 
+On the other hand, there are many of us developers, tinkerers, and general computer enthusiasts who have extra storage 
+space on our home servers.
 
-The idea for Arken is to build an autonomous system for organizing, balancing, and distributing this data to users who can donate their extra space. 
+The goal of Arken is to build an autonomous system for organizing, balancing, and distributing this data among users who 
+can donate their extra space. 
 
 ```
 +------------GitHub/GitLab/GitTea------------+
-|    +--------+   +--------+   +--------+    |
-|    | KeySet |   | KeySet |   | KeySet |    |
-|    +----|---+   +----|\---+   +----|---+    |
-+---------|------------|-\-----------|--------+
+|    +--------+   +--------+    +--------+   |
+|    | Keyset |   | Keyset |    | Keyset |   |
+|    +----|---+   +----|\--+    +----|---+   |
++---------|------------|-\-----------|-------+
           |            |  \          /\
           |            |   \        /  \
           |            |    \      /    \
@@ -37,28 +40,42 @@ The idea for Arken is to build an autonomous system for organizing, balancing, a
 
 # What is Arken?
 
-Arken is management engine that runs on top of the IPFS (Interplanetary File System) protocol. Each instance of Arken calculates which important files are hosted by the fewest number of other nodes on the network and should be locally backed up to reduce the risk of data loss. Arken also knows how much space it's using on your system and will respect limits you set by looking to locally delete data that is backed up by more than 10% of the cluster. 
+Arken is a management engine that runs on top of the IPFS (Interplanetary File System) protocol. Each instance of Arken 
+calculates which important files are hosted by the fewest number of other nodes on the network and should thus be 
+locally backed up to reduce the risk of data loss. Arken also knows how much space it's using on your system and will 
+respect limits you set by locally deleting data that is backed up by more than 10% of the cluster. 
 
 ### What's a Keyset?
 
-A Keyset is how Arken transparently keeps track of knowing which files are important to the network and thus should be monitored and backed up if needed. Unlike a Pinset in an IPFS cluster,  a Keyset is simply a plain text git repository made of up file identifiers which makes it easy to audit so you actually know what data you're helping to preserve. Keyset repositories can contain an arbitrary number of directories used to organize keyset files as long as they also contain a keyset.config YAML file. This config file provides both a lighthouse file identifier used to measure the total number of nodes subscribed to that keyset, and a replication factor that is the percentage of the total network that should be storing a file at any one time.
+Arken uses Keysets to transparently keep track of which files are important to the network and should be
+monitored and backed up if needed. Unlike a Pinset in an IPFS cluster, a Keyset is simply a plain text git repository
+made of up file identifiers. Additionally, Keysets are easy to audit so you can actually know what data you're helping
+preserve. Keyset repositories can contain an arbitrary number of directories used to organize keyset files as long as 
+they also contain a `keyset.config` YAML file. This config file provides both a lighthouse file identifier used to 
+measure the total number of nodes subscribed to that Keyset, and a replication factor that is the percentage of the
+total network that should be storing a file at any given time.
 
-While Keysets tell Arken which files should be stored on the subscribed nodes. A Keyset doesn't contain any of the data to backup onto the network. To import data to a Keyset users add files to IPFS and record the File Identifiers (IPFS CID) to a keyset file. From there nodes will begin pulling data directly from the user to the cluster.
+While Keysets tell Arken which files should be stored on the subscribed nodes, they don't contain any of the
+data to be backed up onto the network. To import data to a Keyset, users add files to IPFS and record the File 
+Identifiers (IPFS CID) to a keyset file. From there, nodes will begin pulling data directly from the user to the cluster.
 
 ##### Keyset Security
 
-Because Keysets are openly available through Git repositories they can be easily audited and can only be changed by users who have access to those git repositories or through pull requests.
+Since Keysets are openly available through Git repositories, they can be easily audited but can only be changed by 
+users who have access to those Git repositories or through pull requests.
 
-##### Rebalancing Data Across the Comunity
+##### Rebalancing Data Across the Community
 
-On a regular interval an instance of Arken will query IPFS for the number of other nodes hosting a particular file and if any files are below the optimal threshhold Arken will look to replace one well backed up file on the system with an at risk file.
+Arken instances will periodically query IPFS for the number of other nodes hosting a particular file and attempt to 
+replace one well backed up file on the system with files below the optimal threshold.
 
 ## Getting Started
 
 #### Tutorials:
 [Getting Started with Arken on a Raspberry Pi](https://github.com/arkenproject/arken/blob/master/docs/raspberry-pi-setup.md)
 
-To start running an Arken Node you can download it as a Golang program or as a docker container. **For simplicity and easy updates it is recommended to run Arken as a docker container.** 
+To start running a node, you can download Arken as a Golang program or as a Docker container. 
+**It's recommended to run Arken as a Docker container for simplicity and ease of updating.** 
 
 ##### Docker:
 
@@ -84,10 +101,23 @@ go get github.com/arkenproject/arken
 go run arken
 ```
 
-### What's the process as someone who want's to backup important data?
+### What's the process as someone who wants to back up important data?
 
-Let's say that you are a scholar who want's to perseve some important works of humanity, or a researcher who want's to backup the DNA of an extinct animal/plant. How would you go about adding your data to the distributed file system? First, you would load the Arken Import Tool, and point it at the directory of important data. The tool will now create a keyset file of the IPFS identifiers for your data. At this point you can either upload the keyset to your own git repository (best if you want to run your own pool of workers) or make an application to put your data in the core keyset repository. This core keyset repository will be made up of extremely important data to preserve and is what the community donating their extra disk space will use by default.
+Let's say that you are a scholar who wants to preserve some important works of humanity, or a researcher who wants 
+to back up the DNA of an extinct animal/plant. How would you go about adding your data to the distributed file system? 
+First, you would load the Arken Import Tool, and point it at the directory of important data. The tool will create 
+a Keyset file of the IPFS identifiers for your data. At this point you can either upload the Keyset to your own Git 
+repository (this is best if you want to run your own pool of workers) or make an application to put your data in the
+core Keyset repository. This core Keyset repository will consist of extremely important data to preserve and is what the 
+community donating their extra disk space will use by default.
 
 ### What's the process as someone donating their extra storage space?
 
-Let's say that you have an old computer or server that has some storage space sitting empty on it. After installing the Arken program, you'll be asked how much storage space and network bandwidth you're willing to donate to the community pool. The Core Keyset will be available by default but because Keysets are just github repositories you can add and use any keysets you'd like. (For example, you're donating space to the core community pool but also want to sync a custom Keyset of some vacation pictures between you and a few friends' machines.) After the configuration that's it! Arken will continue to run in the background, determining files with the fewest number of other nodes hosting them and priorize backing them up to your node.
+Old computers or servers with some empty storage space make excellent Arken nodes. After installing the 
+Arken program, you'll be asked how much storage space and network bandwidth you're willing to donate to the community 
+pool. The core Keyset will be available by default, but because Keysets are just Git repositories, you can add and use 
+any Keyset you'd like. For example, you can donate space to the core community pool but also sync a custom Keyset of 
+some vacation pictures amongst yours and a few friends' machines.
+
+After the configuration, that's it! Arken will continue to run in the background, determining files with the fewest 
+number of other nodes hosting them and rebalancing as necessary.


### PR DESCRIPTION
This commit fixes various typos, enforces capitalization consistency with words like "Git" and "Keyset", fixes the `#what's-a-keyset` link, adjusts the formatting on the ASCII diagram, and attempts to clear up some convoluted/dense language. Also, it cuts all the textual lines to around 120 chars.