### PR TITLE
add support for floating point numbers in pool max 

### DIFF
--- a/config/disk.go
+++ b/config/disk.go
@@ -29,19 +29,19 @@ func (di *DiskInfo) GetDiskInfo() *DiskInfo {
 // GlobalDiskInfo is the Global Configuration struct for Arken disk stats
 var GlobalDiskInfo DiskInfo
 
-//ParsePoolSize parses the string contained in the global config as the max pool size, and
-//stores the value it comes up with in bytes in the struct GlobalDiskInfo. If
+//ParsePoolSize parses the string contained in the global config as the max pool size,
+//and stores the value it comes up with in bytes in the struct GlobalDiskInfo. If
 //for some reason the input cannot be understood or the user attempts to allocate
 //more storage than they have available, a default value of the user's capacity
 //minus 10 GB will be put in place. This means that the minimum amount of space
 //a user must have available is 10 GB.
 //The string must be in the following format and order:
-//  1. A base-10 integer that does not start with 0
+//  1. A base-10 number, can be floating point
 //  2. One of the following: B, KB, MB, GB, or TB. It's case sensitive to avoid
 //     bit/byte confusion.
 //There can be any amount of whitespace before and after either of the elements.
-//  "3000MB", "  10    GB   ", "10 GB" will all work.
-//  "010GB", "10gb", "0xfa5GB" will not work
+//  "3000MB", "  10GB   ", "10 GB", "1.75TB", ".5 TB" will all work.
+//  "1.TB", "10gb", "0xfa5MB" will not work
 func ParsePoolSize(dip DiskInfoProvider) {
 	di := dip.GetDiskInfo()
 	di.Refresh()
@@ -52,20 +52,30 @@ func ParsePoolSize(dip DiskInfoProvider) {
 		log.Fatal("Not enough free storage on this device")
 	}
 	var poolSizeB uint64
-	parentRegex := regexp.MustCompile("\\A\\s*[1-9]\\d*\\s*[KMGT]?B\\s*$")
+	parentRegex := regexp.MustCompile(
+		"\\A\\s*([0-9]*\\.)?([0-9]\\d*)\\s*[KMGT]?B\\s*$",
+	)
 	if strings.EqualFold(max, "max") { //case insensitive comparison
 		poolSizeB = di.AvailableBytes
 		Global.General.PoolSize = fmt.Sprintf("%vB", di.AvailableBytes)
 	} else if parentRegex.MatchString(max) {
 		poolSizeB = parseWellFormedPoolSize(max)
 	} else { //did not match parent regex
-		log.Printf("Unable to understand \"%v\" as max pool size,"+
+		log.Printf("Unable to understand \"%v\" as max pool size," +
 			" using %v GB instead\n", max, defaultSizeGB)
+		log.Println(`
+The string must be in the following format and order:
+  1. A base-10 number, can be floating point
+  2. One of the following: B, KB, MB, GB, or TB. It's case sensitive to avoid
+     bit/byte confusion.
+There can be any amount of whitespace before and after either of the elements.
+  "3000MB", "  10GB   ", "10 GB", "1.75TB", ".5 TB" will all work.
+  "1.TB", "10gb", "0xfa5MB" will not work`)
 		poolSizeB = uint64(defaultSizeB)
 		Global.General.PoolSize = fmt.Sprintf("%vB", defaultSizeB)
 	}
 	if poolSizeB > di.AvailableBytes {
-		log.Printf("Less than the requested %v GB are free on this computer, "+
+		log.Printf("Less than the requested %v GB are free on this computer, " +
 			"using %v GB instead\n", toGB(poolSizeB), defaultSizeGB)
 		poolSizeB = uint64(defaultSizeB)
 		Global.General.PoolSize = fmt.Sprintf("%vB", defaultSizeB)
@@ -74,19 +84,20 @@ func ParsePoolSize(dip DiskInfoProvider) {
 }
 
 func parseWellFormedPoolSize(str string) uint64 {
-	bytesStr := regexp.MustCompile("[1-9]\\d*").FindString(str) //extract the number
-	unitStr := regexp.MustCompile("[KMGT]?B").FindString(str)   //extract the unit of storage
-	bytes, _ := strconv.ParseUint(bytesStr, 10, 64)             //convert number to uint64
+	bytesStr := regexp.MustCompile("([0-9]*\\.)?([0-9]\\d*)").FindString(str) //extract the number
+	unitStr := regexp.MustCompile("[KMGT]?B").FindString(str)                 //extract the unit of storage
+	fBytes, _ := strconv.ParseFloat(bytesStr,64)                           //convert number to uint64
 	switch unitStr {
 	case "TB":
-		bytes *= uint64(math.Pow10(12))
+		fBytes *= math.Pow10(12)
 	case "GB":
-		bytes *= uint64(math.Pow10(9))
+		fBytes *= math.Pow10(9)
 	case "MB":
-		bytes *= uint64(math.Pow10(6))
+		fBytes *= math.Pow10(6)
 	case "KB":
-		bytes *= uint64(math.Pow10(3))
+		fBytes *= math.Pow10(3)
 	}
+	bytes := uint64(fBytes)
 	if bytes < 1000000000 {
 		log.Fatal("Arken requires an allocation of at least 1 GB")
 	}


### PR DESCRIPTION
Users can now enter floating point numbers in the max pool size
parameter. For example, ".75 TB" will now work. Also, if the user's
input could not be parsed, the program now issues a more verbose error,
basically reflecting the comment above the method.